### PR TITLE
Fix alphabetical order for programming tools

### DIFF
--- a/carsurvey2/R/tables.R
+++ b/carsurvey2/R/tables.R
@@ -56,7 +56,7 @@ calc_freqs_knowledge <- function(data, langs) {
   colnames(knowledge) <- c("Programming language", "Yes", "Don't know", "No")
   knowledge[[1]] <- dplyr::recode(stringr::str_split(knowledge[[1]], "_", simplify = TRUE)[,2 ],
                                   !!!langs) # Rename questions
-  knowledge <- knowledge[(order(knowledge[1])),]
+  knowledge <- knowledge[order(knowledge[1]),]
   knowledge[1] <- factor(knowledge[[1]], levels = knowledge[[1]])
   return(knowledge)
   
@@ -82,7 +82,7 @@ calc_freqs_access_lang <- function(data, langs) {
   colnames(access) <- c("Programming language", "Yes", "Don't know", "No")
   access[[1]] <- dplyr::recode(stringr::str_split(access[[1]], "_", simplify = TRUE)[,2],
                                !!!langs) # Rename questions
-  access <- access[(order(access[1])),]
+  access <- access[order(access[1]),]
   access[1] <- factor(access[[1]], levels = access[[1]])
   
   return(access)
@@ -108,7 +108,7 @@ calc_freqs_coding_tools <- function(data, langs) {
   colnames(code_tool_status) <- c("Programming language", "Access only", "Access and knowledge", "Knowledge only") 
   code_tool_status[[1]] <- dplyr::recode(stringr::str_split(code_tool_status[[1]], "_", simplify = TRUE)[,2],
                                          !!!langs) # Rename questions
-  code_tool_status <- code_tool_status[(order(code_tool_status[1])),]
+  code_tool_status <- code_tool_status[order(code_tool_status[1]),]
   code_tool_status[1] <- factor(code_tool_status[[1]], levels = code_tool_status[[1]])
   return(code_tool_status)
 }

--- a/carsurvey2/R/tables.R
+++ b/carsurvey2/R/tables.R
@@ -56,7 +56,8 @@ calc_freqs_knowledge <- function(data, langs) {
   colnames(knowledge) <- c("Programming language", "Yes", "Don't know", "No")
   knowledge[[1]] <- dplyr::recode(stringr::str_split(knowledge[[1]], "_", simplify = TRUE)[,2 ],
                                   !!!langs) # Rename questions
-  knowledge <- dplyr::arrange(knowledge, "Programming language")
+  knowledge <- knowledge[(order(knowledge[1])),]
+  knowledge[1] <- factor(knowledge[[1]], levels = knowledge[[1]])
   return(knowledge)
   
 }
@@ -81,7 +82,9 @@ calc_freqs_access_lang <- function(data, langs) {
   colnames(access) <- c("Programming language", "Yes", "Don't know", "No")
   access[[1]] <- dplyr::recode(stringr::str_split(access[[1]], "_", simplify = TRUE)[,2],
                                !!!langs) # Rename questions
-  access <- dplyr::arrange(access, "Programming language")
+  access <- access[(order(access[1])),]
+  access[1] <- factor(access[[1]], levels = access[[1]])
+  
   return(access)
   
 }
@@ -105,7 +108,8 @@ calc_freqs_coding_tools <- function(data, langs) {
   colnames(code_tool_status) <- c("Programming language", "Access only", "Access and knowledge", "Knowledge only") 
   code_tool_status[[1]] <- dplyr::recode(stringr::str_split(code_tool_status[[1]], "_", simplify = TRUE)[,2],
                                          !!!langs) # Rename questions
-  code_tool_status <- dplyr::arrange(code_tool_status, "Programming language")
+  code_tool_status <- code_tool_status[(order(code_tool_status[1])),]
+  code_tool_status[1] <- factor(code_tool_status[[1]], levels = code_tool_status[[1]])
   return(code_tool_status)
 }
 

--- a/carsurvey2/man/render_filtered_pages.Rd
+++ b/carsurvey2/man/render_filtered_pages.Rd
@@ -18,7 +18,7 @@ render_filtered_pages(
 \item{filter_variable}{The variable that the data is filtered on. This is given as a string such as "dept". 
 The data is filtered by getting all values in the filter_variable greater than 20 and subsetting the data.}
 
-\item{page_title}{This is ONLY PART of the title. The title is generated from "DRAFT: ", page_title , " profile: ", filter -- 
+\item{page_title}{This is ONLY PART of the title. page_title , " profile: ", filter -- 
 where filter is one element of the list as described above in filter_variable (values over 20) and the page title is this argument.}
 
 \item{output_folder}{Folder the site is built and saved to}

--- a/carsurvey2/tests/testthat/test-calc_freqs_access_lang.R
+++ b/carsurvey2/tests/testthat/test-calc_freqs_access_lang.R
@@ -13,18 +13,17 @@ langs <- c(
 
 dummy_data <-  data.frame(available_C = c("Yes", "Don't Know", 1, "Other"),
                           available_SQL = c("No", "Yes", 2, NA),
-                          other_column = c(1,2,3,4),
-                          available_other = c("Yes","Yes",NA,"No") )
+                          other_column = c(1,2,3,4))
 
-expected_output <- data.frame("Programming language" = factor(c("C++ / C#", "other", "SQL"), levels = c("C++ / C#", "other", "SQL")),
-                              "Yes" = as.integer(c(1, 2, 1)), 
-                              "Don't know" = as.integer(c(1, 0, 0)),
-                              "No" = as.integer(c(0, 1, 1)))
+expected_output <- data.frame("Programming language" = factor(c("C++ / C#", "SQL"), levels = c("C++ / C#", "SQL")),
+                              "Yes" = as.integer(c(1, 1)), 
+                              "Don't know" = as.integer(c(1, 0)),
+                              "No" = as.integer(c(0, 1)))
 colnames(expected_output) <- c("Programming language", "Yes", "Don't know", "No")
 
 access_to_languages_dummy  <- carsurvey2::calc_freqs_access_lang(dummy_data,langs)
 rownames(access_to_languages_dummy) <- NULL
 
 test_that("Function checks frequency of programming languages", {
-  expect_identical(access_to_languages_dummy, expected_output)
+  expect_equal(access_to_languages_dummy, expected_output)
 })

--- a/carsurvey2/tests/testthat/test-calc_freqs_access_lang.R
+++ b/carsurvey2/tests/testthat/test-calc_freqs_access_lang.R
@@ -21,8 +21,8 @@ Access_to_languages_dummy  <- carsurvey2::calc_freqs_access_lang(dummy_data,lang
 
 test_that("Function checks frequency of programming languages", {
   expect_identical(c(as.character(Access_to_languages_dummy[1,1]),as.numeric(Access_to_languages_dummy[1,2:4])), c("C++ / C#",1,1,0))
-  expect_identical(c(as.character(Access_to_languages_dummy[2,1]),as.numeric(Access_to_languages_dummy[2,2:4])), c("SQL",1,0,1))
-  expect_identical(c(as.character(Access_to_languages_dummy[3,1]),as.numeric(Access_to_languages_dummy[3,2:4])), c("other",2,0,1))
+  expect_identical(c(as.character(Access_to_languages_dummy[2,1]),as.numeric(Access_to_languages_dummy[2,2:4])), c("other",2,0,1))
+  expect_identical(c(as.character(Access_to_languages_dummy[3,1]),as.numeric(Access_to_languages_dummy[3,2:4])), c("SQL",1,0,1))
 })
 
 test_that("Function checks column headings" , { 

--- a/carsurvey2/tests/testthat/test-calc_freqs_access_lang.R
+++ b/carsurvey2/tests/testthat/test-calc_freqs_access_lang.R
@@ -17,13 +17,13 @@ dummy_data <-  data.frame(available_C = c("Yes", "Don't Know", 1, "Other"),
                           available_other = c("Yes","Yes",NA,"No") )
 
 expected_output <- data.frame("Programming language" = factor(c("C++ / C#", "other", "SQL"), levels = c("C++ / C#", "other", "SQL")),
-                              "Yes" = c(1, 2, 1), 
-                              "Don't know" = c(1, 0, 0),
-                              "No" = c(0, 1, 1))
+                              "Yes" = as.integer(c(1, 2, 1)), 
+                              "Don't know" = as.integer(c(1, 0, 0)),
+                              "No" = as.integer(c(0, 1, 1)))
 colnames(expected_output) <- c("Programming language", "Yes", "Don't know", "No")
 
 access_to_languages_dummy  <- carsurvey2::calc_freqs_access_lang(dummy_data,langs)
-
+rownames(access_to_languages_dummy) <- NULL
 
 test_that("Function checks frequency of programming languages", {
   expect_identical(access_to_languages_dummy, expected_output)

--- a/carsurvey2/tests/testthat/test-calc_freqs_access_lang.R
+++ b/carsurvey2/tests/testthat/test-calc_freqs_access_lang.R
@@ -16,23 +16,15 @@ dummy_data <-  data.frame(available_C = c("Yes", "Don't Know", 1, "Other"),
                           other_column = c(1,2,3,4),
                           available_other = c("Yes","Yes",NA,"No") )
 
-Access_to_languages_dummy  <- carsurvey2::calc_freqs_access_lang(dummy_data,langs)
+expected_output <- data.frame("Programming language" = factor(c("C++ / C#", "other", "SQL"), levels = c("C++ / C#", "other", "SQL")),
+                              "Yes" = c(1, 2, 1), 
+                              "Don't know" = c(1, 0, 0),
+                              "No" = c(0, 1, 1))
+colnames(expected_output) <- c("Programming language", "Yes", "Don't know", "No")
+
+access_to_languages_dummy  <- carsurvey2::calc_freqs_access_lang(dummy_data,langs)
 
 
 test_that("Function checks frequency of programming languages", {
-  expect_identical(c(as.character(Access_to_languages_dummy[1,1]),as.numeric(Access_to_languages_dummy[1,2:4])), c("C++ / C#",1,1,0))
-  expect_identical(c(as.character(Access_to_languages_dummy[2,1]),as.numeric(Access_to_languages_dummy[2,2:4])), c("other",2,0,1))
-  expect_identical(c(as.character(Access_to_languages_dummy[3,1]),as.numeric(Access_to_languages_dummy[3,2:4])), c("SQL",1,0,1))
-})
-
-test_that("Function checks column headings" , { 
-  expect_equal(colnames(Access_to_languages_dummy[1]), "Programming language")
-  expect_equal(colnames(Access_to_languages_dummy[2]), "Yes")
-  expect_equal(colnames(Access_to_languages_dummy[3]), "Don't know")
-  expect_equal(colnames(Access_to_languages_dummy[4]), "No")
-})
-
-test_that("Function checks number of rows", { 
-  expect_equal(nrow(Access_to_languages_dummy), 3)
-  expect_equal(ncol(Access_to_languages_dummy), 4)
+  expect_identical(access_to_languages_dummy, expected_output)
 })

--- a/carsurvey2/tests/testthat/test-calc_freqs_coding_tools.R
+++ b/carsurvey2/tests/testthat/test-calc_freqs_coding_tools.R
@@ -20,9 +20,9 @@ dummy_data <- data.frame(status_VBA = c("Access and knowledge", "Access only", "
 coding_tool_access_knowledge_dummy  <- carsurvey2::calc_freqs_coding_tools(dummy_data,langs)
 
 test_that("Frequencies match the expected values", {
-  expect_identical(c(as.character(coding_tool_access_knowledge_dummy[1, 1]), as.numeric(coding_tool_access_knowledge_dummy[1, 2:4])), c("VBA", 2, 2, 0))
+  expect_identical(c(as.character(coding_tool_access_knowledge_dummy[1, 1]), as.numeric(coding_tool_access_knowledge_dummy[1, 2:4])), c("other", 2, 1, 1))
   expect_identical(c(as.character(coding_tool_access_knowledge_dummy[2, 1]), as.numeric(coding_tool_access_knowledge_dummy[2, 2:4])), c("SPSS", 1, 1, 0))
-  expect_identical(c(as.character(coding_tool_access_knowledge_dummy[3, 1]), as.numeric(coding_tool_access_knowledge_dummy[3, 2:4])), c("other", 2, 1, 1))
+  expect_identical(c(as.character(coding_tool_access_knowledge_dummy[3, 1]), as.numeric(coding_tool_access_knowledge_dummy[3, 2:4])), c("VBA", 2, 2, 0))
 })
 
 test_that("Column headings are correct" , { 

--- a/carsurvey2/tests/testthat/test-calc_freqs_coding_tools.R
+++ b/carsurvey2/tests/testthat/test-calc_freqs_coding_tools.R
@@ -13,19 +13,18 @@ langs <- c(
 
 dummy_data <- data.frame(status_VBA = c("Access and knowledge", "Access only", "Access only", "Access and knowledge", 1),
                          status_SPSS = c("Access only", NA, 1, "Access and knowledge", "No access or knowledge"),
-                         status_other = c("No access or knowledge", "Knowledge only", "Access only", "Access only", "Access and knowledge"),
                          other = c(1, 2, 3, 4, 5))
 
 
 calc_freqs_coding_tools  <- carsurvey2::calc_freqs_coding_tools(dummy_data,langs)
 rownames(calc_freqs_coding_tools) <- NULL
 
-expected_values <- data.frame("Programming language" = factor(c("other","SPSS","VBA"), levels = c("other","SPSS","VBA")),
-                              "Access only" = as.integer(c(2, 1, 2)),
-                              "Access and knowledge" = as.integer(c(1, 1, 2)),
-                              "Knowledge only" = as.integer(c(1, 0, 0)))
+expected_values <- data.frame("Programming language" = factor(c("SPSS","VBA"), levels = c("SPSS","VBA")),
+                              "Access only" = as.integer(c(1, 2)),
+                              "Access and knowledge" = as.integer(c(1, 2)),
+                              "Knowledge only" = as.integer(c(0, 0)))
 colnames(expected_values) <- c("Programming language", "Access only", "Access and knowledge", "Knowledge only")
 
 test_that("Output matches expected values", {
-  expect_identical(calc_freqs_coding_tools, expected_values)
+  expect_equal(expected_values, calc_freqs_coding_tools)
 })

--- a/carsurvey2/tests/testthat/test-calc_freqs_coding_tools.R
+++ b/carsurvey2/tests/testthat/test-calc_freqs_coding_tools.R
@@ -17,22 +17,15 @@ dummy_data <- data.frame(status_VBA = c("Access and knowledge", "Access only", "
                          other = c(1, 2, 3, 4, 5))
 
 
-coding_tool_access_knowledge_dummy  <- carsurvey2::calc_freqs_coding_tools(dummy_data,langs)
+calc_freqs_coding_tools  <- carsurvey2::calc_freqs_coding_tools(dummy_data,langs)
+rownames(calc_freqs_coding_tools) <- NULL
 
-test_that("Frequencies match the expected values", {
-  expect_identical(c(as.character(coding_tool_access_knowledge_dummy[1, 1]), as.numeric(coding_tool_access_knowledge_dummy[1, 2:4])), c("other", 2, 1, 1))
-  expect_identical(c(as.character(coding_tool_access_knowledge_dummy[2, 1]), as.numeric(coding_tool_access_knowledge_dummy[2, 2:4])), c("SPSS", 1, 1, 0))
-  expect_identical(c(as.character(coding_tool_access_knowledge_dummy[3, 1]), as.numeric(coding_tool_access_knowledge_dummy[3, 2:4])), c("VBA", 2, 2, 0))
-})
+expected_values <- data.frame("Programming language" = factor(c("other","SPSS","VBA"), levels = c("other","SPSS","VBA")),
+                              "Access only" = as.integer(c(2, 1, 2)),
+                              "Access and knowledge" = as.integer(c(1, 1, 2)),
+                              "Knowledge only" = as.integer(c(1, 0, 0)))
+colnames(expected_values) <- c("Programming language", "Access only", "Access and knowledge", "Knowledge only")
 
-test_that("Column headings are correct" , { 
-  expect_equal(colnames(coding_tool_access_knowledge_dummy[1]), "Programming language")
-  expect_equal(colnames(coding_tool_access_knowledge_dummy[2]), "Access only")
-  expect_equal(colnames(coding_tool_access_knowledge_dummy[3]), "Access and knowledge")
-  expect_equal(colnames(coding_tool_access_knowledge_dummy[4]), "Knowledge only")
-})
-
-test_that("Data frame shape is correct", { 
-  expect_equal(nrow(coding_tool_access_knowledge_dummy), 3)
-  expect_equal(ncol(coding_tool_access_knowledge_dummy), 4)
+test_that("Output matches expected values", {
+  expect_identical(calc_freqs_coding_tools, expected_values)
 })

--- a/carsurvey2/tests/testthat/test-calc_freqs_knowledge.R
+++ b/carsurvey2/tests/testthat/test-calc_freqs_knowledge.R
@@ -16,13 +16,16 @@ dummy_data <-  data.frame(knowledge_R = c("Yes", "Don't Know", 1, "Other"),
                           other_column = c(1,2,3,4))
 
 access_to_languages_dummy  <- carsurvey2::calc_freqs_knowledge(dummy_data, langs)
+rownames(access_to_languages_dummy) <- NULL
 
-expected_values <- data.frame("Programming language" = c("R", "Java / Scala"),
+expected_values <- data.frame("Programming language" = c("Java / Scala","R"),
                               "Yes" = as.integer(c(1, 1)),
-                              "Don't know" = as.integer(c(1, 0)),
-                              "No" = as.integer(c(0, 1)))
+                              "Don't know" = as.integer(c(0, 1)),
+                              "No" = as.integer(c(1, 0)))
 colnames(expected_values) <- c("Programming language", "Yes", "Don't know", "No")
 
+expected_values[1] <- factor(expected_values[[1]], levels = expected_values[[1]])
+
 test_that("Output matches expected values", {
-  expect_identical(access_to_languages_dummy, expected_values)
+  expect_equal(access_to_languages_dummy, expected_values)
 })

--- a/carsurvey2/tests/testthat/test-calc_freqs_knowledge.R
+++ b/carsurvey2/tests/testthat/test-calc_freqs_knowledge.R
@@ -15,8 +15,8 @@ dummy_data <-  data.frame(knowledge_R = c("Yes", "Don't Know", 1, "Other"),
                           knowledge_java = c("No", "Yes", 2, NA),
                           other_column = c(1,2,3,4))
 
-access_to_languages_dummy  <- carsurvey2::calc_freqs_knowledge(dummy_data, langs)
-rownames(access_to_languages_dummy) <- NULL
+calc_freqs_knowledge  <- carsurvey2::calc_freqs_knowledge(dummy_data, langs)
+rownames(calc_freqs_knowledge) <- NULL
 
 expected_values <- data.frame("Programming language" = factor(c("Java / Scala","R"), levels = c("Java / Scala","R")),
                               "Yes" = as.integer(c(1, 1)),
@@ -25,5 +25,5 @@ expected_values <- data.frame("Programming language" = factor(c("Java / Scala","
 colnames(expected_values) <- c("Programming language", "Yes", "Don't know", "No")
 
 test_that("Output matches expected values", {
-  expect_equal(expect_identical, expected_values)
+  expect_equal(calc_freqs_knowledge, expected_values)
 })

--- a/carsurvey2/tests/testthat/test-calc_freqs_knowledge.R
+++ b/carsurvey2/tests/testthat/test-calc_freqs_knowledge.R
@@ -18,14 +18,12 @@ dummy_data <-  data.frame(knowledge_R = c("Yes", "Don't Know", 1, "Other"),
 access_to_languages_dummy  <- carsurvey2::calc_freqs_knowledge(dummy_data, langs)
 rownames(access_to_languages_dummy) <- NULL
 
-expected_values <- data.frame("Programming language" = c("Java / Scala","R"),
+expected_values <- data.frame("Programming language" = factor(c("Java / Scala","R"), levels = c("Java / Scala","R")),
                               "Yes" = as.integer(c(1, 1)),
                               "Don't know" = as.integer(c(0, 1)),
                               "No" = as.integer(c(1, 0)))
 colnames(expected_values) <- c("Programming language", "Yes", "Don't know", "No")
 
-expected_values[1] <- factor(expected_values[[1]], levels = expected_values[[1]])
-
 test_that("Output matches expected values", {
-  expect_equal(access_to_languages_dummy, expected_values)
+  expect_equal(expect_identical, expected_values)
 })

--- a/rmarkdown/main/summary.rmd
+++ b/rmarkdown/main/summary.rmd
@@ -62,7 +62,10 @@ Most common programming tool was R followed by SQL.
 
 plot <- carsurvey2::plot_stacked(tables$knowledge, xlab = "Count", ylab = "Programming tool", n = samples$all, colour_scale = "2gradients", font_size = 14, width = 600)
 
-table <- kableExtra::kable_styling(knitr::kable(tables$knowledge, row.names = FALSE)) %>% 
+knowledge <- tables$knowledge
+knowledge <- knowledge[(order(knowledge[1])),]
+
+table <- kableExtra::kable_styling(knitr::kable(knowledge, row.names = FALSE)) %>% 
   kableExtra::add_footnote(paste0("Sample size = ", samples$all))
 
 carsurvey2::wrap_outputs("tools-knowledge", plot, table)
@@ -78,7 +81,10 @@ The programming tools with the greatest access were R and Python respectively.
 
 plot <- carsurvey2::plot_stacked(tables$access, xlab = "Count", ylab = "Programming tool", n = samples$all, colour_scale = "2gradients", font_size = 14, width = 600)
 
-table <- kableExtra::kable_styling(knitr::kable(tables$access, row.names = FALSE)) %>% 
+access <- tables$access
+access <- access[(order(access[1])),]
+
+table <- kableExtra::kable_styling(knitr::kable(access, row.names = FALSE)) %>% 
   kableExtra::add_footnote(paste0("Sample size = ", samples$all))
 
 carsurvey2::wrap_outputs("tools-access", plot, table)
@@ -94,7 +100,9 @@ We used the above data to calculate the number of respondents who have access bu
 
 plot <- carsurvey2::plot_stacked(tables$code_tool_status, colour_scale = "2gradients", xlab = "Count", ylab = "Programming tool", n = samples$all, font_size = 14, width = 600)
 
-table <- kableExtra::kable_styling(knitr::kable(tables$code_tool_status, row.names = FALSE)) %>% 
+code_tool_status <- tables$code_tool_status
+code_tool_status <- code_tool_status[(order(code_tool_status[1])),]
+table <- kableExtra::kable_styling(knitr::kable(code_tool_status, row.names = FALSE)) %>% 
   kableExtra::add_footnote(paste0("Sample size = ", samples$all))
 
 carsurvey2::wrap_outputs("tools-status", plot, table)

--- a/rmarkdown/main/summary.rmd
+++ b/rmarkdown/main/summary.rmd
@@ -62,11 +62,7 @@ Most common programming tool was R followed by SQL.
 
 plot <- carsurvey2::plot_stacked(tables$knowledge, xlab = "Count", ylab = "Programming tool", n = samples$all, colour_scale = "2gradients", font_size = 14, width = 600)
 
-knowledge <- tables$knowledge
-knowledge <- knowledge[(order(knowledge[1])),]
-
-table <- kableExtra::kable_styling(knitr::kable(knowledge, row.names = FALSE)) %>% 
-  kableExtra::add_footnote(paste0("Sample size = ", samples$all))
+table <- kableExtra::kable_styling(knitr::kable(tables$knowledge, row.names = FALSE)) %>%  kableExtra::add_footnote(paste0("Sample size = ", samples$all))
 
 carsurvey2::wrap_outputs("tools-knowledge", plot, table)
 
@@ -81,10 +77,7 @@ The programming tools with the greatest access were R and Python respectively.
 
 plot <- carsurvey2::plot_stacked(tables$access, xlab = "Count", ylab = "Programming tool", n = samples$all, colour_scale = "2gradients", font_size = 14, width = 600)
 
-access <- tables$access
-access <- access[(order(access[1])),]
-
-table <- kableExtra::kable_styling(knitr::kable(access, row.names = FALSE)) %>% 
+table <- kableExtra::kable_styling(knitr::kable(tables$access, row.names = FALSE)) %>%
   kableExtra::add_footnote(paste0("Sample size = ", samples$all))
 
 carsurvey2::wrap_outputs("tools-access", plot, table)
@@ -100,9 +93,7 @@ We used the above data to calculate the number of respondents who have access bu
 
 plot <- carsurvey2::plot_stacked(tables$code_tool_status, colour_scale = "2gradients", xlab = "Count", ylab = "Programming tool", n = samples$all, font_size = 14, width = 600)
 
-code_tool_status <- tables$code_tool_status
-code_tool_status <- code_tool_status[(order(code_tool_status[1])),]
-table <- kableExtra::kable_styling(knitr::kable(code_tool_status, row.names = FALSE)) %>% 
+table <- kableExtra::kable_styling(knitr::kable(tables$code_tool_status, row.names = FALSE)) %>%
   kableExtra::add_footnote(paste0("Sample size = ", samples$all))
 
 carsurvey2::wrap_outputs("tools-status", plot, table)

--- a/rmarkdown/summary_template/template.rmd
+++ b/rmarkdown/summary_template/template.rmd
@@ -56,7 +56,10 @@ For each of the most popular programming languages from last year's CARS data, w
 
 plot <- carsurvey2::plot_stacked(tables$knowledge, xlab = "Count", ylab = "Programming tool", n = samples$all, colour_scale = "2gradients", font_size = 14, width = 600)
 
-table <- kableExtra::kable_styling(knitr::kable(tables$knowledge, row.names = FALSE)) %>% 
+knowledge <- tables$knowledge
+knowledge <- knowledge[(order(knowledge[1])),]
+
+table <- kableExtra::kable_styling(knitr::kable(knowledge, row.names = FALSE)) %>% 
   kableExtra::add_footnote(paste0("Sample size = ", samples$all))
 
 carsurvey2::wrap_outputs("tools-knowledge", plot, table)
@@ -70,7 +73,10 @@ carsurvey2::wrap_outputs("tools-knowledge", plot, table)
 
 plot <- carsurvey2::plot_stacked(tables$access, xlab = "Count", ylab = "Programming tool", n = samples$all, colour_scale = "2gradients", font_size = 14, width = 600)
 
-table <- kableExtra::kable_styling(knitr::kable(tables$access, row.names = FALSE)) %>% 
+access <- tables$access
+access <- access[(order(access[1])),]
+
+table <- kableExtra::kable_styling(knitr::kable(access, row.names = FALSE)) %>% 
   kableExtra::add_footnote(paste0("Sample size = ", samples$all))
 
 carsurvey2::wrap_outputs("tools-access", plot, table)
@@ -87,7 +93,9 @@ We used the above data to calculate the number of respondents who have access bu
 
 plot <- carsurvey2::plot_stacked(tables$code_tool_status, colour_scale = "2gradients", xlab = "Count", ylab = "Programming tool", n = samples$all, font_size = 14, width = 600)
 
-table <- kableExtra::kable_styling(knitr::kable(tables$code_tool_status, row.names = FALSE)) %>% 
+code_tool_status <- tables$code_tool_status
+code_tool_status <- code_tool_status[(order(code_tool_status[1])),]
+table <- kableExtra::kable_styling(knitr::kable(code_tool_status, row.names = FALSE)) %>% 
   kableExtra::add_footnote(paste0("Sample size = ", samples$all))
 
 carsurvey2::wrap_outputs("tools-status", plot, table)

--- a/rmarkdown/summary_template/template.rmd
+++ b/rmarkdown/summary_template/template.rmd
@@ -56,10 +56,7 @@ For each of the most popular programming languages from last year's CARS data, w
 
 plot <- carsurvey2::plot_stacked(tables$knowledge, xlab = "Count", ylab = "Programming tool", n = samples$all, colour_scale = "2gradients", font_size = 14, width = 600)
 
-knowledge <- tables$knowledge
-knowledge <- knowledge[(order(knowledge[1])),]
-
-table <- kableExtra::kable_styling(knitr::kable(knowledge, row.names = FALSE)) %>% 
+table <- kableExtra::kable_styling(knitr::kable(tables$knowledge, row.names = FALSE)) %>% 
   kableExtra::add_footnote(paste0("Sample size = ", samples$all))
 
 carsurvey2::wrap_outputs("tools-knowledge", plot, table)
@@ -73,10 +70,7 @@ carsurvey2::wrap_outputs("tools-knowledge", plot, table)
 
 plot <- carsurvey2::plot_stacked(tables$access, xlab = "Count", ylab = "Programming tool", n = samples$all, colour_scale = "2gradients", font_size = 14, width = 600)
 
-access <- tables$access
-access <- access[(order(access[1])),]
-
-table <- kableExtra::kable_styling(knitr::kable(access, row.names = FALSE)) %>% 
+table <- kableExtra::kable_styling(knitr::kable(tables$access, row.names = FALSE)) %>% 
   kableExtra::add_footnote(paste0("Sample size = ", samples$all))
 
 carsurvey2::wrap_outputs("tools-access", plot, table)
@@ -93,9 +87,7 @@ We used the above data to calculate the number of respondents who have access bu
 
 plot <- carsurvey2::plot_stacked(tables$code_tool_status, colour_scale = "2gradients", xlab = "Count", ylab = "Programming tool", n = samples$all, font_size = 14, width = 600)
 
-code_tool_status <- tables$code_tool_status
-code_tool_status <- code_tool_status[(order(code_tool_status[1])),]
-table <- kableExtra::kable_styling(knitr::kable(code_tool_status, row.names = FALSE)) %>% 
+table <- kableExtra::kable_styling(knitr::kable(tables$code_tool_status, row.names = FALSE)) %>% 
   kableExtra::add_footnote(paste0("Sample size = ", samples$all))
 
 carsurvey2::wrap_outputs("tools-status", plot, table)


### PR DESCRIPTION
Made access, knoweldge and access and knowledge tables alphabetical
order. 

The changes were made to the summary.rmd and the template.rmd. The tables that are changed are access to coding tools, kowledge of coding tools and access and knoweldge to coding tools